### PR TITLE
Fix display install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ DCGAN.torch: Train your own image generator
 ## Display UI
 Optionally, for displaying images during training and generation, we will use the [display package](https://github.com/szym/display).
 
-- Install it with: `luarocks install display`
+- Install it with: `luarocks install https://raw.githubusercontent.com/szym/display/master/display-scm-0.rockspec`
 - Then start the server with: `th -ldisplay.start`
 - Open this URL in your browser: [http://localhost:8000](http://localhost:8000)
 


### PR DESCRIPTION
The current instructions install another display package that does not have anything to do with szym/display. I updated the installation instructions so that we can be sure the correct package is installed.