### PR TITLE
-L switch is needed for "find" to handle symlinked data subfolders

### DIFF
--- a/data/dataset.lua
+++ b/data/dataset.lua
@@ -135,7 +135,7 @@ function dataset:__init(...)
    -- define command-line tools, try your best to maintain OSX compatibility
    local wc = 'wc'
    local cut = 'cut'
-   local find = 'find'
+   local find = 'find -L' -- -L is necessary when the subfolders themselves are symlinks
    if ffi.os == 'OSX' then
       wc = 'gwc'
       cut = 'gcut'


### PR DESCRIPTION
Without -L switch, subfolders (ie. class folders) that are symlinks are ignored by the "find" utility (tested with GNU find v4.5.12)